### PR TITLE
Update emit ready in index.js - baileys provider

### DIFF
--- a/packages/provider/src/baileys/index.js
+++ b/packages/provider/src/baileys/index.js
@@ -74,8 +74,8 @@ class BaileysProvider extends ProviderClass {
 
                 /** Conexion abierta correctamente */
                 if (connection === 'open') {
-                    this.emit('ready', true)
                     this.initBusEvents(sock)
+                    this.emit('ready', true)
                 }
 
                 /** QR Code */


### PR DESCRIPTION
lanzar el evento "ready" una vez este seteada la propiedad vendor en la clase

# Que tipo de Pull Request es?

- [x] Mejoras
- [ ] Bug
- [ ] Docs / tests

# Descripción

Actualmente el evento se lanza antes de definir los eventos de baileys asi como sin setear la propiedad vendor en la clase, al ser el ready del provider debería lanzarse ya definido todo lo del provider.
